### PR TITLE
Search by time range instead of single time

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -20,9 +20,11 @@ const activateEvents = function () {
 // activates time selector and calls getCurrentAttraction function
 const activateTimeSelector = () =>{
     $('#time-selector').on("change", function () {
-        let currentTime = `2013-02-08 ${$('#time-selector').val()}`;
-        currentTime = moment(currentTime); // converts to a moment object but doesn't format
-        let currentAttractions = timeFormatter.getCurrentAttractions(currentTime);
+        let selectedTime = $('#time-selector').val();
+        let todaysDate= moment();
+        todaysDate = todaysDate.format('MM-DD-YYYY');
+        let dateAndTime = moment(`${todaysDate} ${selectedTime}`);
+        let currentAttractions = timeFormatter.getCurrentAttractions(dateAndTime);
     });
 };
     

--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -20,10 +20,10 @@ const activateEvents = function () {
 // activates time selector and calls getCurrentAttraction function
 const activateTimeSelector = () =>{
     $('#time-selector').on("change", function () {
-        let selectedTime = $('#time-selector').val();
-        let todaysDate= moment().format('MM-DD-YYYY');
-        let dateAndTime = moment(`${todaysDate} ${selectedTime}`);
-        let currentAttractions = timeFormatter.getCurrentAttractions(dateAndTime);
+        let selectedTime = $('#time-selector').val(); // grab the selected time 
+        let todaysDate= moment().format('MM-DD-YYYY'); // get todays date 
+        let dateAndTime = moment(`${todaysDate} ${selectedTime}`);  // make a moment object with today's date and the selected time 
+        let currentAttractions = timeFormatter.getCurrentAttractions(dateAndTime); // pass the moment object into the timeFormatter module to get attractions happening at that time
     });
 };
     

--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -21,8 +21,7 @@ const activateEvents = function () {
 const activateTimeSelector = () =>{
     $('#time-selector').on("change", function () {
         let selectedTime = $('#time-selector').val();
-        let todaysDate= moment();
-        todaysDate = todaysDate.format('MM-DD-YYYY');
+        let todaysDate= moment().format('MM-DD-YYYY');
         let dateAndTime = moment(`${todaysDate} ${selectedTime}`);
         let currentAttractions = timeFormatter.getCurrentAttractions(dateAndTime);
     });

--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -21,7 +21,7 @@ const activateEvents = function () {
 const activateTimeSelector = () =>{
     $('#time-selector').on("change", function () {
         let currentTime = `2013-02-08 ${$('#time-selector').val()}`;
-        currentTime = moment(currentTime).format("h:mmA");
+        currentTime = moment(currentTime); // converts to a moment object but doesn't format
         let currentAttractions = timeFormatter.getCurrentAttractions(currentTime);
     });
 };

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -23,7 +23,8 @@ Promise.all(promiseArr)
     }
     domController.displayAreaGrid(areas);  // displays area grid
     timeFormatter.getAttractionsWithHours(attractions); // accepts all attractions and returns attractions that have hours
-    let currentTime = moment().format("HH:mmA"); // gets current time with moment
+    let currentTime = moment(); // this is a moment object that will get formatted in getCurrentAttractions
+    // let currentTime = moment().format("HH:mmA"); // gets current time with moment
     timeFormatter.getCurrentAttractions(currentTime); //passes in current time and returns an array of attractions happening at that time
     
 });

--- a/assets/js/timeFormatter.js
+++ b/assets/js/timeFormatter.js
@@ -3,6 +3,7 @@
 const $ = require('jquery');
 const printToDom = require('./dom');
 const dataFormatter = require('./dataFormatter');
+const moment = require('moment');
 
 let attractionsWithAreas = [];
 
@@ -21,11 +22,14 @@ module.exports.getAttractionsWithHours = (allAttractions) => {
 };
 
 // accepts a time, goes through attractions with areas attached, searches for attractions that match the time you passed in
-module.exports.getCurrentAttractions = (time) => {
+module.exports.getCurrentAttractions = (startTime) => {
+    let endTime = moment(startTime).add(1, 'hours').format("HH:mmA");
+    console.log("this should be an hour after the time you entered", endTime);
     let currentAttractions = [];
+    // moment('2010-10-20').isBetween('2010-10-19', '2010-10-25'); // true
     attractionsWithAreas.forEach(attractionObject => {
         let timesArray = attractionObject.times;
-        if (timesArray.indexOf(time) != -1){
+        if (timesArray.indexOf(startTime) != -1){
             currentAttractions.push(attractionObject);
         }
         printToDom.displayTimeAttractions(currentAttractions);

--- a/assets/js/timeFormatter.js
+++ b/assets/js/timeFormatter.js
@@ -24,7 +24,7 @@ module.exports.getAttractionsWithHours = (allAttractions) => {
 // accepts a time, goes through attractions with areas attached, searches for attractions that match the time you passed in
 module.exports.getCurrentAttractions = (startTime) => {
     let currentAttractions = [];
-    let endTime = moment(startTime).add(1, 'hours'); // adds an hour to the time you pass in and formats it correctly
+    let endTime = moment(startTime).add(1, 'hours');
     attractionsWithAreas.forEach(attractionObject => {
         let timesArray = attractionObject.times;
         timesArray.forEach(time => {
@@ -33,7 +33,6 @@ module.exports.getCurrentAttractions = (startTime) => {
                 currentAttractions.push(attractionObject);
             }
         });
-        console.log(currentAttractions);
         printToDom.displayTimeAttractions(currentAttractions);
     });
 };

--- a/assets/js/timeFormatter.js
+++ b/assets/js/timeFormatter.js
@@ -23,15 +23,23 @@ module.exports.getAttractionsWithHours = (allAttractions) => {
 
 // accepts a time, goes through attractions with areas attached, searches for attractions that match the time you passed in
 module.exports.getCurrentAttractions = (startTime) => {
-    let endTime = moment(startTime).add(1, 'hours').format("HH:mmA");
-    console.log("this should be an hour after the time you entered", endTime);
     let currentAttractions = [];
-    // moment('2010-10-20').isBetween('2010-10-19', '2010-10-25'); // true
+    let endTime = moment(startTime).add(1, 'hours'); // adds an hour to the time you pass in and formats it correctly
+    console.log("this should be the start time", startTime);
+    console.log("this should be the end time", endTime);
     attractionsWithAreas.forEach(attractionObject => {
         let timesArray = attractionObject.times;
-        if (timesArray.indexOf(startTime) != -1){
-            currentAttractions.push(attractionObject);
-        }
+        timesArray.forEach(time => {
+            console.log("this should be a moment object of the time in the time array", moment(time));
+            if (moment(time).isBetween(startTime, endTime), 'hour'){
+                console.log(attractionObject, "this starts soon!");
+                currentAttractions.push(attractionObject);
+            }
+        });
+        console.log("this should be the current attractions array", currentAttractions);
+        // if (timesArray.indexOf(startTime) != -1 ){
+        //     currentAttractions.push(attractionObject);
+        // }
         printToDom.displayTimeAttractions(currentAttractions);
     });
 };

--- a/assets/js/timeFormatter.js
+++ b/assets/js/timeFormatter.js
@@ -21,19 +21,20 @@ module.exports.getAttractionsWithHours = (allAttractions) => {
     });
 };
 
-// accepts a time, goes through attractions with areas attached, searches for attractions that match the time you passed in
+// accepts a start time from main.js and events.js (when the page loads or when you select at time)
+// this function DOESN'T WORK when the page loads because attractions with areas is an empty array at that point, so this is gonna need to be a callback for formatting all the attractions with area names
 module.exports.getCurrentAttractions = (startTime) => {
-    let currentAttractions = [];
-    let endTime = moment(startTime).add(1, 'hours');
+    let currentAttractions = []; 
+    let endTime = moment(startTime).add(1, 'hours'); // adds one hour to start time (for example, if you enter 10:00 AM, the end time will be 11:00 AM)
     attractionsWithAreas.forEach(attractionObject => {
         let timesArray = attractionObject.times;
         timesArray.forEach(time => {
-            time = moment(time, 'h:mmA');
-            if (moment(time).isBetween(startTime, endTime)){
-                currentAttractions.push(attractionObject);
+            time = moment(time, 'h:mmA'); // loops through the times array in each attraction, convert time string to moment object
+            if (moment(time).isBetween(startTime, endTime)){ // checks to see if moment object is within an hour of your start time
+                currentAttractions.push(attractionObject); // if so, push it into the currentAttractions array
             }
         });
-        printToDom.displayTimeAttractions(currentAttractions);
+        printToDom.displayTimeAttractions(currentAttractions); // send the current attractions array to the printer
     });
 };
 

--- a/assets/js/timeFormatter.js
+++ b/assets/js/timeFormatter.js
@@ -24,22 +24,20 @@ module.exports.getAttractionsWithHours = (allAttractions) => {
 // accepts a time, goes through attractions with areas attached, searches for attractions that match the time you passed in
 module.exports.getCurrentAttractions = (startTime) => {
     let currentAttractions = [];
-    let endTime = moment(startTime).add(1, 'hours'); // adds an hour to the time you pass in and formats it correctly
-    console.log("this should be the start time", startTime);
-    console.log("this should be the end time", endTime);
+    let endTime = moment(startTime).add(1, 'hours').format('h:MMA'); // adds an hour to the time you pass in and formats it correctly
+    startTime = startTime.format('h:MMA');
+    console.log("end time", endTime);
+    console.log("start time", startTime);
     attractionsWithAreas.forEach(attractionObject => {
         let timesArray = attractionObject.times;
         timesArray.forEach(time => {
-            console.log("this should be a moment object of the time in the time array", moment(time));
-            if (moment(time).isBetween(startTime, endTime), 'hour'){
-                console.log(attractionObject, "this starts soon!");
+            time = moment(time, 'h:MMA');
+            // moment(time).format('h:MMA');
+            console.log("this is the time of the attraction, should be formatted the same", time);
+            if (moment(time).isBetween(startTime, endTime)){
                 currentAttractions.push(attractionObject);
             }
         });
-        console.log("this should be the current attractions array", currentAttractions);
-        // if (timesArray.indexOf(startTime) != -1 ){
-        //     currentAttractions.push(attractionObject);
-        // }
         printToDom.displayTimeAttractions(currentAttractions);
     });
 };

--- a/assets/js/timeFormatter.js
+++ b/assets/js/timeFormatter.js
@@ -24,20 +24,16 @@ module.exports.getAttractionsWithHours = (allAttractions) => {
 // accepts a time, goes through attractions with areas attached, searches for attractions that match the time you passed in
 module.exports.getCurrentAttractions = (startTime) => {
     let currentAttractions = [];
-    let endTime = moment(startTime).add(1, 'hours').format('h:MMA'); // adds an hour to the time you pass in and formats it correctly
-    startTime = startTime.format('h:MMA');
-    console.log("end time", endTime);
-    console.log("start time", startTime);
+    let endTime = moment(startTime).add(1, 'hours'); // adds an hour to the time you pass in and formats it correctly
     attractionsWithAreas.forEach(attractionObject => {
         let timesArray = attractionObject.times;
         timesArray.forEach(time => {
-            time = moment(time, 'h:MMA');
-            // moment(time).format('h:MMA');
-            console.log("this is the time of the attraction, should be formatted the same", time);
+            time = moment(time, 'h:mmA');
             if (moment(time).isBetween(startTime, endTime)){
                 currentAttractions.push(attractionObject);
             }
         });
+        console.log(currentAttractions);
         printToDom.displayTimeAttractions(currentAttractions);
     });
 };

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -75,6 +75,10 @@ footer {
     .attraction-type {
         font-style: italic;
     }
+    .attraction-times{
+        font-size: 0.7rem;
+        color: rgb(82, 80, 80);
+    }
 }
 
 #attraction-list{

--- a/assets/templates/timeAttr.hbs
+++ b/assets/templates/timeAttr.hbs
@@ -6,7 +6,13 @@
     <p class = "attraction-type">({{this.areaName}})</p>
     <div class = "attraction-details isHidden">
         <p class="attraction-description">{{this.description}}</p>
-        <p class = "attraction-times">{{this.times}}</p>
+         {{#if this.times}}
+        <ul>
+            {{#each times}}
+            <li>{{this}}</li>
+            {{/each}}
+        </ul>
+        {{/if}}
     </div>
 </div>
 {{/each}}

--- a/assets/templates/timeAttr.hbs
+++ b/assets/templates/timeAttr.hbs
@@ -6,7 +6,7 @@
     <p class = "attraction-type">({{this.areaName}})</p>
     <div class = "attraction-details isHidden">
         <p class="attraction-description">{{this.description}}</p>
-        {{!-- <p class="attraction-hours">{{this.times[0]}} to {{this.times[times.length]}}</p> --}}
+        <p class = "attraction-times">{{this.times}}</p>
     </div>
 </div>
 {{/each}}

--- a/index.html
+++ b/index.html
@@ -42,7 +42,6 @@
                         <span>Search by Time</span>
                         <input min = "01:00:00" max = "12:59:59" placeholder="Choose a Time" type="time" id="time-selector" class="form-control timepicker time-selector">
                     </div>
-                    <h3>Area grid</h3>
                     <div id="area-grid"></div>
                 </div>
             </div>


### PR DESCRIPTION
- When you select a time with the time selector, attractions that start within an hour of the time you selected should display in the left sidebar

- I added the times to the handlebars template mainly for testing purposes so y'all can check and make sure that the start times match up with the time you selected. Right now they print as an array so it looks wonky, BUT I figured when we make our shiny new attractions formatting module we could just include a function to format that array into a string and tack that on to the attraction object too

- (If we super hate the way those times look, I can just take them out for now and stick them back in later)

- This feature DOES NOT WORK on page load because it requires an array of attractions formatted with the areas attached. When this function fires, the attractionsWithAreas array is empty. I didn't want to wade into that without y'all, but I have a feeling it'll fix itself once we go through our refactor this afternoon 

-YEEHAW